### PR TITLE
Add building workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: "Building"
+
+on:
+  push:
+    branches: [python-binding]
+
+  pull_request:
+    branches: [python-binding]
+
+jobs:
+  build:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: [3.12]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build using Python ${{matrix.python-version}}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{matrix.python-version}}
+
+      - name: Installing [pip]
+        run: |
+          pip install --upgrade pip
+          pip install .


### PR DESCRIPTION
This PR adds a building workflow so that we can assess if a commit breaks the ability to build the project.

It checks installation on ubuntu and windows.

Edit: still need to figure out what's going on for `ubuntu`; it works for `windows` though. (see https://github.com/luisfpereira/rematching/actions/runs/12092218474/job/33721674220?pr=1)